### PR TITLE
feat!: dice roller throws error on bad expressions if no callback

### DIFF
--- a/.changeset/kind-donkeys-do.md
+++ b/.changeset/kind-donkeys-do.md
@@ -1,0 +1,5 @@
+---
+"nat20": minor
+---
+
+Dice roller now throws an error on invalid expressions if no callback is provided

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ npm install nat20
 import { DiceRoller, d } from "nat20";
 
 const diceRoller = new DiceRoller();
-const result = diceRoller.roll("2d6"); // Should return a number between 2 and 12
 
-// With a callback 
+diceRoller.roll("2d6"); // Should return a number between 2 and 12
+
+diceRoller.roll("2a6"); // Should throw an erro due to this being an invalid expression
+
+// Alternatively, you can use a callback
 diceRoller.roll("d6 + 6", (result, error) => {
-    // result should be a number between 7 anad 12
-    // if the expression is invalid, you can access the error here
+    // The result should be a number between 7 anad 12
+    // Tf the expression is invalid, you can access the error message here instead of it being thrown
 });
 
-// Or, simply roll a single d20
+// You can also simply roll a single dice, taking the number of sides as a parameter
 const result = d(20) // Should return a number between 1 and 20
 ```

--- a/src/dice-roller.test.ts
+++ b/src/dice-roller.test.ts
@@ -44,10 +44,15 @@ describe("DiceRoller = Simple Tests", () => {
 
 describe("DiceRoller - Error Handling", () => {
 	const diceRoller = new DiceRoller();
-	test("2x6 - Result should be an error due to invalid character", () => {
+	test("2x6 - Callback - Should return an error due to invalid character", () => {
 		diceRoller.roll("2x6", (_, error) => {
 			expect(error).toBeDefined();
 			expect(error).length.is.greaterThan(0);
 		});
+	});
+	test("2x6 - No Callback - Should throw an error due to invalid character", () => {
+		expect(() => diceRoller.roll("2x6")).toThrowError(
+			"Invalid characters entered: x",
+		);
 	});
 });

--- a/src/dice-roller.test.ts
+++ b/src/dice-roller.test.ts
@@ -46,8 +46,7 @@ describe("DiceRoller - Error Handling", () => {
 	const diceRoller = new DiceRoller();
 	test("2x6 - Callback - Should return an error due to invalid character", () => {
 		diceRoller.roll("2x6", (_, error) => {
-			expect(error).toBeDefined();
-			expect(error).length.is.greaterThan(0);
+			expect(error).toEqual("Invalid characters entered: x");
 		});
 	});
 	test("2x6 - No Callback - Should throw an error due to invalid character", () => {

--- a/src/dice-roller.ts
+++ b/src/dice-roller.ts
@@ -85,9 +85,12 @@ export class DiceRoller {
 			}
 			this.rolls = [];
 			this.resultText = `${rollText} - Failed to perform dice roll - ${errorMessage}`;
-			if (typeof callback === "function")
+			if (typeof callback === "function") {
 				callback({ value: 0, rolls: [], resultText: "" }, errorMessage);
-			return 0;
+				return 0;
+			}
+			// If no callback provided then throw the error
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
BREAKING CHANGE

The `DiceRoller.roll` method now throws an error if an invalid expression is provided, unless a callback is provided.